### PR TITLE
Prevent reflection when paired with higher version of commons-codec

### DIFF
--- a/src/crypto/random.clj
+++ b/src/crypto/random.clj
@@ -25,7 +25,7 @@
 (defn hex
   "Return a random hex string of the specified size in bytes."
   [size]
-  (String. (Hex/encodeHex (bytes size))))
+  (String. (Hex/encodeHex ^bytes (bytes size))))
 
 (defn url-part
   "Return a random string suitable for being inserted into URLs. The size


### PR DESCRIPTION
When using `ring-codec` which uses `commons-codec` 1.11 new overloads of `encodeHex` are introduced, which causes reflection warnings on this particular line (and prevents the use ring in graal native compilation).

This fixes the issue.